### PR TITLE
update: Vercel Vite 배포시 라우터 새로고침 404 에러

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
+}


### PR DESCRIPTION
update: Vercel Vite 배포시 라우터 새로고침 404 에러

{
  "rewrites": [{ "source": "/(.*)", "destination": "/" }]
}
